### PR TITLE
WebRTC: adding call to 'close_connection' endpoint on page reloading

### DIFF
--- a/webgear_rtc/static/js/custom.js
+++ b/webgear_rtc/static/js/custom.js
@@ -116,3 +116,10 @@ function resize() {
 // call resize
 resize();
 window.onresize = resize;
+
+// Call 'close_connection' endpoint to inform server that we are refreshing page
+window.onbeforeunload = function(event)
+{
+    pc.close();
+    axios.post('/close_connection', 1)
+};

--- a/webgear_rtc/templates/base.html
+++ b/webgear_rtc/templates/base.html
@@ -33,6 +33,8 @@ limitations under the License.
   <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800' rel='stylesheet' type='text/css'>
   <link href='//fonts.googleapis.com/css?family=Rubik:900' rel='stylesheet' type='text/css'>
   <!--//web font-->
+  <!-- Axios framework for async requests -->
+  <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
It is needed to restart peer connetion and a videostream.
Related to this PR: https://github.com/abhiTronix/vidgear/pull/221